### PR TITLE
reverting python changes due to lack of latest python kubernetes client available on the BCI image

### DIFF
--- a/Nessie/Dockerfile
+++ b/Nessie/Dockerfile
@@ -5,8 +5,8 @@ FROM registry.suse.com/bci/bci-base:15.6
 RUN zypper --non-interactive ref && \
     zypper --non-interactive install \
     python311 \
-    python311-PyYAML \
-    python311-kubernetes \
+#    python311-PyYAML \
+#    python3-kubernetes \
     helm \
     systemd \
     util-linux \
@@ -14,7 +14,7 @@ RUN zypper --non-interactive ref && \
     podman
 
 # Use pip to install kubernetes client
-#RUN python3.12 -m pip install pyyaml kubernetes
+RUN python3.11 -m pip install pyyaml kubernetes
 
 # Set the working directory inside the container
 WORKDIR /app


### PR DESCRIPTION
reverting python changes due to lack of latest python kubernetes client available on the BCI image